### PR TITLE
removed overloaded * operator, cross, doc, and entrywise products of vectors

### DIFF
--- a/vec.cpp
+++ b/vec.cpp
@@ -10,16 +10,29 @@ vec3 vec3::AddVec3(const vec3 a, const vec3 b) const {
 	return c;
 };
 
-vec3 vec3::MultVec3(const vec3 a, const vec3 b) const {
-
-	vec3 c;
-
-	c.x = a.x * b.x;
-	c.y = a.y * b.y;
-	c.z = a.z * b.z;
-
-	return c;
+vec3 vec3::entrywise_product(const vec3& a, const vec3& b) const {
+	return vec3(a.x * b.x, a.y * b.y, a.z * b.z);
 };
+
+vec3 vec3::entrywise_product( const vec3& b) const {
+	return entrywise_product(*this, b);
+};
+
+float vec3::dot_product(const vec3& a, const vec3& b) const {
+	return a.x*b.x + a.y*b.y + a.z*b.z;
+}
+
+float vec3::dot_product(const vec3& b) const {
+	return dot_product(*this, b);
+}
+
+vec3 vec3::cross_product(const vec3& a, const vec3& b) const {
+	return vec3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);
+}
+
+vec3 vec3::cross_product(const vec3& b) const {
+	return cross_product(*this, b);
+}
 
 float vec3::length() const {
 	return sqrt(x*x+y*y+z*z);
@@ -41,13 +54,8 @@ vec3& vec3::operator +=( const vec3& rhs ) {
 	return *this;
 }
 
-vec3 vec3::operator *( const vec3& rhs ) const {
-	return MultVec3( *this, rhs );
-}
-
 vec3 vec3::operator *(float rhs) const {
-	vec3 scale(rhs,rhs,rhs);
-	return scale * (*this);
+	return entrywise_product(vec3(rhs,rhs,rhs));
 }
 
 bool vec3::operator ==( const vec3& rhs) const {

--- a/vec.hpp
+++ b/vec.hpp
@@ -9,28 +9,32 @@
  * and some convenient constructors
 */
 class vec3 {
- 
-  public:
-	  float x, y, z;
-  vec3() : x(0), y(0), z(0) {}
-  vec3(float in_x, float in_y, float in_z) : x(in_x), y(in_y), z(in_z) {}
-  vec3(const vec3 &in) : x(in.x), y(in.y), z(in.z) {}
-  vec3 AddVec3(const vec3 a, const vec3 b) const;
-  vec3 MultVec3(const vec3 a, const vec3 b) const;
-  float length() const;
-  vec3& operator =( const vec3& rhs );
-  vec3 operator +( const vec3& rhs ) const;
-  vec3& operator +=( const vec3& rhs );
-  vec3 operator *( const vec3& rhs ) const;
-  vec3 operator *(float rhs) const;
-  bool operator ==( const vec3& rhs) const;
+	private:
+
+	public:
+	float x, y, z;
+	vec3() : x(0), y(0), z(0) {}
+	vec3(float in_x, float in_y, float in_z) : x(in_x), y(in_y), z(in_z) {}
+	vec3(const vec3 &in) : x(in.x), y(in.y), z(in.z) {}
+	vec3 AddVec3(const vec3 a, const vec3 b) const;
+	float length() const;
+	vec3& operator =( const vec3& rhs );
+	vec3 operator +( const vec3& rhs ) const;
+	vec3& operator +=( const vec3& rhs );
+	bool operator ==( const vec3& rhs) const;
 	vec3 operator -( const vec3& rhs ) const;
 	bool negative() const;
 	vec3 max_components( const vec3& rhs ) const;
 	vec3 min_components( const vec3& rhs ) const;
+	vec3 entrywise_product(const vec3& a, const vec3& b) const;
+	float dot_product(const vec3& a, const vec3& b) const;
+	vec3 cross_product(const vec3& a, const vec3& b) const;
+	vec3 entrywise_product(const vec3& b) const;
+	float dot_product(const vec3& b) const;
+	vec3 cross_product(const vec3& b) const;
+	vec3 operator *(float rhs) const;
+	friend const vec3 operator*( float lhs, const vec3& rhs);
 };
-
-const vec3 operator*( float lhs, const vec3& rhs);
 
 struct vec4 {
     struct vec3;


### PR DESCRIPTION
I originally overloaded * for entrywise multiplication, but since vector multiplication could mean dot, cross, or entrywise products, overloading * for two vectors is ambiguous so i removed it. I left in overloaded scalar multiplication, though, because float*vector can only mean scalar multiplication.